### PR TITLE
wireguard-go userspace implemenation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apk add --no-cache \
     iptables \
     jq \
     openssl \
+    git \
+    go \
+    make \
     wireguard-tools
 
 ENV LOCAL_NETWORK= \
@@ -17,11 +20,15 @@ ENV LOCAL_NETWORK= \
     PORT_FORWARDING=0 \
     PORT_PERSIST=0 \
     EXIT_ON_FATAL=0 \
-    FIREWALL=1
+    FIREWALL=1 \
+    WG_USERSPACE=0
 
 # Modify wg-quick so it doesn't die without --privileged
 # Set net.ipv4.conf.all.src_valid_mark=1 on container creation using --sysctl if required instead
 RUN sed -i 's/cmd sysctl.*/set +e \&\& sysctl -q net.ipv4.conf.all.src_valid_mark=1 \&\& set -e/' /usr/bin/wg-quick
+
+# Install wireguard-go as a fallback if wireguard is not supported by the host OS or Linux kernel
+RUN cd / && git clone https://git.zx2c4.com/wireguard-go && cd wireguard-go && make && mv wireguard-go /usr/bin/ && cd / && rm -rf /wireguard-go
 
 # Get the PIA CA cert
 ADD https://raw.githubusercontent.com/pia-foss/desktop/master/daemon/res/ca/rsa_4096.crt /rsa_4096.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ RUN apk add --no-cache \
     iptables \
     jq \
     openssl \
-    git \
-    go \
-    make \
     wireguard-tools
 
 ENV LOCAL_NETWORK= \
@@ -28,7 +25,7 @@ ENV LOCAL_NETWORK= \
 RUN sed -i 's/cmd sysctl.*/set +e \&\& sysctl -q net.ipv4.conf.all.src_valid_mark=1 \&\& set -e/' /usr/bin/wg-quick
 
 # Install wireguard-go as a fallback if wireguard is not supported by the host OS or Linux kernel
-RUN cd / && git clone https://git.zx2c4.com/wireguard-go && cd wireguard-go && make && mv wireguard-go /usr/bin/ && cd / && rm -rf /wireguard-go
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing wireguard-go
 
 # Get the PIA CA cert
 ADD https://raw.githubusercontent.com/pia-foss/desktop/master/daemon/res/ca/rsa_4096.crt /rsa_4096.crt

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Docker container for using WireGuard with PIA.
 
 ## Requirements
-* The WireGuard kernel module must already be installed on the host.
+* The WireGuard kernel module must already be installed on the host. Alternatively a userspace implementation can be enabled using the WG_USERSPACE environment variable.
 * An active [PIA](https://www.privateinternetaccess.com) subscription.
 
 ## Config
@@ -26,6 +26,7 @@ The rest are optional:
 |```PORT_PERSIST=0/1```|Set to 1 to attempt to keep the same port forwarded when the container is restarted. The port number may persist for up to two months. Defaults to 0 (always acquire a new port number) if not specified.
 |```FIREWALL=0/1```|Whether to block non-WireGuard traffic. Defaults to 1 if not specified.
 |```EXIT_ON_FATAL=0/1```|There is no error recovery logic at this stage. If something goes wrong we simply go to sleep. By default the container will continue running until manually stopped. Set this to 1 to force the container to exit when an error occurs. Exiting on an error may not be desirable behaviour if other containers are sharing the connection.
+|```WG_USERSPACE=0/1```|If the host OS or host Linux kernel does not support wireguard (certain NAS systems), a userspace implementation ([wireguard-go](https://git.zx2c4.com/wireguard-go/about/)) can be enabled. Defaults to 0 if not specified.
 
 ## Notes
 * Based on what was found in the source code to the PIA desktop app.
@@ -37,6 +38,7 @@ The rest are optional:
 * An example [docker-compose.yml](https://github.com/thrnz/docker-wireguard-pia/blob/master/docker-compose.yml) is included.
 * Other containers can share the VPN connection using Docker's [```--net=container:xyz```](https://docs.docker.com/engine/reference/run/#network-settings) or docker-compose's [```network_mode: service:xyz```](https://docs.docker.com/compose/compose-file/#network_mode).
 * Standalone [Bash scripts](https://github.com/thrnz/docker-wireguard-pia/tree/master/extra) are available for use outside of Docker.
+* The userspace implementation through wireguard-go is very stable but lacks in performance. Looking into supporting ([boringtun](https://github.com/cloudflare/boringtun) might be beneficial.
 
 ## Credits
 Some bits and pieces and ideas have been borrowed from the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
             - NET_ADMIN
             # SYS_MODULE might not be needed with a 5.6+ kernel?
             - SYS_MODULE
+        # Mounting the tun device may be necessary for userspace implementations
+        #devices:
+        #  - /dev/net/tun:/dev/net/tun
         environment:
             #- LOCAL_NETWORK=192.168.1.0/24
             - LOC=swiss
@@ -19,6 +22,7 @@ services:
             #- KEEPALIVE=25
             #- VPNDNS=8.8.8.8,8.8.4.4
             - PORT_FORWARDING=1
+            #- WG_USERSPACE=1
         sysctls:
             # wg-quick fails to set this without --privileged, so set it here instead if needed
             - net.ipv4.conf.all.src_valid_mark=1

--- a/run
+++ b/run
@@ -35,7 +35,11 @@ finish () {
   [ $PORT_FORWARDING -eq 1 ] && pkill -f 'pf.sh'
   echo "$(date): Shutting down WireGuard"
   [ -w "$portfile" ] && rm "$portfile"
-  wg-quick down wg0
+  if [ $WG_USERSPACE -eq 1 ]; then
+    WG_QUICK_USERSPACE_IMPLEMENTATION=wireguard-go wg-quick down wg0
+  else
+    wg-quick down wg0
+  fi
   exit 0
 }
 
@@ -95,7 +99,11 @@ fi
 
 # Bring up Wireguard interface
 echo "$(date): Bringing up WireGuard interface wg0"
-wg-quick up wg0 || fatal_error
+if [ $WG_USERSPACE -eq 1 ]; then
+  WG_QUICK_USERSPACE_IMPLEMENTATION=wireguard-go wg-quick up wg0 || fatal_error
+else
+  wg-quick up wg0 || fatal_error
+fi
 
 # Print out wg interface info
 echo


### PR DESCRIPTION
This adds support for [wireguard-go](https://git.zx2c4.com/wireguard-go/about/) to allow this container to run on hosts that don't support wireguard or on Linux kernels that don't support wireguard (some NAS devices).

wireguard-go is not great performance wise and [boringtun](https://github.com/cloudflare/boringtun) or [wireguard-rs](https://git.zx2c4.com/wireguard-rs/) may work better, but I haven't managed to make them work yet.

I tested this PR, both on MacOS 10.14 and a QNAP NAS with QTS 4.4.3.