### PR TITLE
Documentation - Using network_mode: service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The rest are optional:
 
 | ENV Var | Function |
 |-------|------|
-|```LOCAL_NETWORK=192.168.1.0/24```|Whether to route and allow input/output traffic to the LAN. LAN access is blocked by default if not specified. Multiple ranges can be specified, separated by a comma or space.
+|```LOCAL_NETWORK=192.168.1.0/24```|Whether to route and allow input/output traffic to the LAN. LAN access is blocked by default if not specified. Multiple ranges can be specified, separated by a comma or space.<br />⚠This variable is **required** if you intend to connect to a tunneled container via SSH, HTTP, etc. See [docker-compose.yml](docker-compose.yml) for an example.
 |```KEEPALIVE=25```|If defined, PersistentKeepalive will be set to this in the WireGuard config.
 |```VPNDNS=8.8.8.8, 8.8.4.4```|Use these DNS servers in the WireGuard config. Defaults to PIA's DNS servers if not specified.
 |```PORT_FORWARDING=0/1```|Whether to enable port forwarding. Requires a supported server. Defaults to 0 if not specified.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-# This example is written for implementations that allow local access to tunneled containers. For example, if you have a web server or a
-# container that uses a web interface to manage it you'll need to use the configuration below. If you DON'T need this and your containers
-# are only managed through the VPN tunnel you can comment out or omit the LOCAL_NETWORK line.
 version: '3.8'
 services:
     vpn:
@@ -22,9 +19,12 @@ services:
             - LOC=swiss
             - USER=p0000000
             - PASS=xxxxxxxxxxxxxxxx
+            
+            # If you have tunneled containers you need to connect to, you must define LOCAL_NETWORK. See
+            # details below at the [helloworld] definition.
             - LOCAL_NETWORK=192.168.1.0/24 # Substitute your local network subnet.
-            # Example of LOCAL_NETWORK allowing two subnets
-            # - LOCAL_NETWORK=192.168.1.0/24,192.168.42.0/24
+            #- LOCAL_NETWORK=192.168.1.0/24,192.168.42.0/24 Example allowing two local subnets
+            
             # The rest are optional:
             #- KEEPALIVE=25
             #- VPNDNS=8.8.8.8,8.8.4.4
@@ -49,10 +49,10 @@ services:
     # Example of another service sharing the VPN using network_mode: service.  With this mode both containers
     # share the same network stack, so all network definitions are under the parent container.
     # See https://docs.docker.com/engine/reference/run/#network-container and
-    # https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode for technical information
+    # https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode
     helloworld:
         image: nginxdemos/hello
-        network_mode: "service:vpn" # This is the name of the service
+        network_mode: "service:vpn"
         # Port definitions for this container go under the connected container instead.
         #ports:
         #    - 4980:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
-version: '3'
+# This example is written for implementations that allow local access to tunneled containers. For example, if you have a web server or a
+# container that uses a web interface to manage it you'll need to use the configuration below. If you DON'T need this and your containers
+# are only managed through the VPN tunnel you can comment out or omit the LOCAL_NETWORK line.
+version: '3.8'
 services:
     vpn:
         image: thrnz/docker-wireguard-pia
@@ -19,12 +22,16 @@ services:
             - LOC=swiss
             - USER=p0000000
             - PASS=xxxxxxxxxxxxxxxx
+            - LOCAL_NETWORK=192.168.1.0/24 # Substitute your local network subnet.
+            # Example of LOCAL_NETWORK allowing two subnets
+            # - LOCAL_NETWORK=192.168.1.0/24,192.168.42.0/24
             # The rest are optional:
-            #- LOCAL_NETWORK=192.168.1.0/24
             #- KEEPALIVE=25
             #- VPNDNS=8.8.8.8,8.8.4.4
             #- PORT_FORWARDING=1
             #- WG_USERSPACE=1
+        ports:
+            - 4980:80 # This is the port for the helloworld container below.
         sysctls:
             # wg-quick fails to set this without --privileged, so set it here instead if needed
             - net.ipv4.conf.all.src_valid_mark=1
@@ -39,11 +46,16 @@ services:
             timeout: 10s
             retries: 3
 
-    # Example of another service sharing the VPN
-    other-service:
-        image: some-other-image
-        # Other services can share the VPN using 'network_mode'
-        network_mode: "service:vpn"
+    # Example of another service sharing the VPN using network_mode: service.  With this mode both containers
+    # share the same network stack, so all network definitions are under the parent container.
+    # See https://docs.docker.com/engine/reference/run/#network-container and
+    # https://docs.docker.com/compose/compose-file/compose-file-v3/#network_mode for technical information
+    helloworld:
+        image: nginxdemos/hello
+        network_mode: "service:vpn" # This is the name of the service
+        # Port definitions for this container go under the connected container instead.
+        #ports:
+        #    - 4980:80
 
     # Other containers can access the forwarded port number via /pia-shared/port.dat
     # Here's an example of a bare-bones 'helper' container that passes the forwarded port to Deluge


### PR DESCRIPTION
Updated _readme.md_ and _docker-compose.yaml_ to clarify how **network_mode: service** works and that LOCAL_NETWORK is required to access web management portals on connected containers.