### PR TITLE
Update VPNDNS to allow making no changes to DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The rest are optional:
 |```LOCAL_NETWORK=192.168.1.0/24```|Whether to route and allow input/output traffic to the LAN. LAN access is blocked by default if not specified. Multiple ranges can be specified, separated by a comma or space. Note that there may be DNS issues if this overlaps with PIA's default DNS servers (`10.0.0.243` and `10.0.0.242` as of July 2022). Custom DNS servers can be defined using `VPNDNS` (see below) if this is an issue.
 |```KEEPALIVE=25```|If defined, PersistentKeepalive will be set to this in the WireGuard config.
 |```MTU=1420```|This can be used to override ```wg-quick```'s automatic MTU setting on the Wireguard interface if needed. By default this remains unset (ie. let ```wg-quick``` choose).
-|```VPNDNS=8.8.8.8, 8.8.4.4```|Use these DNS servers in the WireGuard config. Defaults to PIA's DNS servers if not specified.
+|```VPNDNS=8.8.8.8, 8.8.4.4```|Use these DNS servers in the WireGuard config. PIA's DNS servers will be used if not specified. Use 0 to disable making any changes to the default container DNS settings.
 |```PORT_FORWARDING=0/1```|Whether to enable port forwarding. Requires a supported server. Defaults to 0 if not specified.
 |```PORT_FILE=/pia-shared/port.dat```|The forwarded port number is dumped here for possible access by scripts in other containers. By default this is ```/pia-shared/port.dat```.
 |```PORT_FILE_CLEANUP=0/1```|Remove the file containing the forwarded port number on exit. Defaults to 0 if not specified.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The rest are optional:
 |```LOCAL_NETWORK=192.168.1.0/24```|Whether to route and allow input/output traffic to the LAN. LAN access is blocked by default if not specified. Multiple ranges can be specified, separated by a comma or space. Note that there may be DNS issues if this overlaps with PIA's default DNS servers (`10.0.0.243` and `10.0.0.242` as of July 2022). Custom DNS servers can be defined using `VPNDNS` (see below) if this is an issue.
 |```KEEPALIVE=25```|If defined, PersistentKeepalive will be set to this in the WireGuard config.
 |```MTU=1420```|This can be used to override ```wg-quick```'s automatic MTU setting on the Wireguard interface if needed. By default this remains unset (ie. let ```wg-quick``` choose).
-|```VPNDNS=8.8.8.8, 8.8.4.4```|Use these DNS servers in the WireGuard config. PIA's DNS servers will be used if not specified. Use 0 to disable making any changes to the default container DNS settings.
+|```VPNDNS=8.8.8.8, 8.8.4.4```|Use these DNS servers in the WireGuard config. PIA's DNS servers will be used if not specified. Use 0 to disable making any changes to the default container DNS settings. (Note: Using any DNS servers other than PIA's may lead to DNS queries being leaked outside the VPN connection.)
 |```PORT_FORWARDING=0/1```|Whether to enable port forwarding. Requires a supported server. Defaults to 0 if not specified.
 |```PORT_FILE=/pia-shared/port.dat```|The forwarded port number is dumped here for possible access by scripts in other containers. By default this is ```/pia-shared/port.dat```.
 |```PORT_FILE_CLEANUP=0/1```|Remove the file containing the forwarded port number on exit. Defaults to 0 if not specified.

--- a/extra/wg-gen.sh
+++ b/extra/wg-gen.sh
@@ -157,6 +157,9 @@ get_wgconf () {
   if [ -z "$dns" ]; then
       dns=$(jq -r '.dns_servers[0:2]' "$addkey_response" | grep ^\  | cut -d\" -f2 | xargs echo | sed -e 's/ /,/g')
       echo "Using PIA DNS servers: $dns"
+  elif [ "$dns" = "0" ]; then
+      echo "Using default container DNS servers"
+      dns=""
   else
       echo "Using custom DNS servers: $dns"
   fi


### PR DESCRIPTION
I currently use this docker container as a 'gateway' for a couple of other containers, but the current VPNDNS functionality means that those containers can no longer connect to other containers in the stack using the container name (as per default docker DNS setup). My local network already uses custom DNS servers which I'm happy to send all requests to, even ones going through a VPN tunnel.

This slight change to the VPNDNS env variable allows you to set it to '0' to not add any DNS servers to the wg0.conf file. This prevents any change being made to /etc/resolv.conf and means the default docker DNS are used.

I've tested the change and it has no impact on previous functionality.