### PR TITLE
Allows special characters in PIA password

### DIFF
--- a/extra/pia-auth.sh
+++ b/extra/pia-auth.sh
@@ -41,15 +41,15 @@ usage() {
 get_auth_token () {
     TOK=$(curl --silent --location --show-error --request POST --max-time "$curl_max_time" \
         'https://www.privateinternetaccess.com/api/client/v2/token' \
-        --form "username=$user" \
-        --form "password=$pass" | jq -r '.token')
+        --form 'username=$user' \
+        --form 'password=$pass' | jq -r '.token')
     if [ -z "$TOK" ]; then
       echo "Failed to acquire new auth token" && exit 1
     fi
     echo "$TOK"
 }
 
-if [ -z "$pass" ] || [ -z "$user" ]; then
+if [ -z '$pass' ] || [ -z '$user' ]; then
   usage
 fi
 

--- a/run
+++ b/run
@@ -129,8 +129,8 @@ gen_wgconf () {
 # Get a new auth token
 # Unsure how long an auth token will remain valid
 get_auth_token () {
-  [ -r "$USER_FILE" ] && echo "$(date): Reading username from $USER_FILE" && USER=$(<"$USER_FILE")
-  [ -r "$PASS_FILE" ] && echo "$(date): Reading password from $PASS_FILE" && PASS=$(<"$PASS_FILE")
+  [ -r "$USER_FILE" ] && echo "$(date): Reading username from $USER_FILE" && USER=$(<'${USER_FILE@Q}')
+  [ -r "$PASS_FILE" ] && echo "$(date): Reading password from $PASS_FILE" && PASS=$(<'${PASS_FILE@Q}')
   [ -z "$PASS" ] && echo "$(date): PIA password not set. Unable to retrieve new auth token." && fatal_error
   [ -z "$USER" ] && echo "$(date): PIA username not set. Unable to retrieve new auth token." && fatal_error
   echo "$(date): Generating auth token"

--- a/run
+++ b/run
@@ -129,12 +129,12 @@ gen_wgconf () {
 # Get a new auth token
 # Unsure how long an auth token will remain valid
 get_auth_token () {
-  [ -r "$USER_FILE" ] && echo "$(date): Reading username from $USER_FILE" && USER=$(<'${USER_FILE@Q}')
-  [ -r "$PASS_FILE" ] && echo "$(date): Reading password from $PASS_FILE" && PASS=$(<'${PASS_FILE@Q}')
+  [ -r "$USER_FILE" ] && echo "$(date): Reading username from $USER_FILE" && USER=$(<'$USER_FILE')
+  [ -r "$PASS_FILE" ] && echo "$(date): Reading password from $PASS_FILE" && PASS=$(<'$PASS_FILE')
   [ -z "$PASS" ] && echo "$(date): PIA password not set. Unable to retrieve new auth token." && fatal_error
   [ -z "$USER" ] && echo "$(date): PIA username not set. Unable to retrieve new auth token." && fatal_error
   echo "$(date): Generating auth token"
-  if ! /scripts/pia-auth.sh -u "$USER" -p "$PASS" > "$tokenfile"; then
+  if ! /scripts/pia-auth.sh -u '$USER' -p '$PASS' > "$tokenfile"; then
     echo "$(date): Failed to acquire new auth token" && fatal_error
   fi
   chmod 600 "$tokenfile"


### PR DESCRIPTION
Small but critical change.

I had a special character in my PIA password, an exclamation mark. This was causing the `run` and `/scripts/pia-auth.sh` bash files to escape on that character, so I was getting the error below when attempting to generate an authentication token:
`docker-wireguard-pia  | Fri Jun  2 21:32:15 UTC 2023: Generating auth token`
`docker-wireguard-pia  | parse error: Invalid numeric literal at line 1, column 5`
`docker-wireguard-pia | Fri Jun  2 21:32:16 UTC 2023: Failed to acquire new auth token`
`docker-wireguard-pia  | Fri Jun  2 21:32:16 UTC 2023: Fatal error`

Calling `/extra/pia-auth.sh` directly with `./pia-auth.sh -u "p12345" -p "example!2345" > ~/.token` produced the error `bash: !2345: event not found`

Fortunately, the fix was relatively easy. Just needed to change the double quotes to single quotes where the username and password was referenced. This allows the username and password to be read/assigned to the variables as string literals, regardless of the characters.

I took this code change, built it with your `Dockerfile`, and tested with multiple different passwords and characters (ie. `thispassword#@*!%&1234`) to confirm this fixed the issue. 

Please let me know if you have any questions. 

[Stack Overflow](https://stackoverflow.com/questions/15783701/which-characters-need-to-be-escaped-when-using-bash)