### PR TITLE
Extra spacing, container name, and alternative image comment. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,79 +1,82 @@
 services:
-    vpn:
-        image: thrnz/docker-wireguard-pia
-        volumes:
-            # Auth token is stored here
-            - pia:/pia
-            # If enabled, the forwarded port is dumped to /pia-shared/port.dat for potential use in other containers
-            - pia-shared:/pia-shared
-        cap_add:
-            - NET_ADMIN
-            # SYS_MODULE might not be needed with a 5.6+ kernel?
-            - SYS_MODULE
-        # If the kernel module isn't available, mounting the tun device may be necessary for userspace implementations
-        #devices:
-        #  - /dev/net/tun:/dev/net/tun
-        environment:
-            # The following env vars are required:
-            - LOC=swiss
-            - USER=xxxxxxxxxxxxxxxx
-            - PASS=xxxxxxxxxxxxxxxx
-            # The rest are optional:
-            #- LOCAL_NETWORK=192.168.1.0/24
-            #- KEEPALIVE=25
-            #- VPNDNS=8.8.8.8,8.8.4.4
-            #- PORT_FORWARDING=1
-        sysctls:
-            # The wg-quick script tries to set this when setting up routing, however this requires running the container
-            # with the --privileged flag set. Setting it here instead if needed means the container can be run with lower
-            # privileges. This only needs setting if strict reverse path filtering (rp_filter=1) is used.
-            - net.ipv4.conf.all.src_valid_mark=1
-            # May as well disable ipv6. Should be blocked anyway.
-            - net.ipv6.conf.default.disable_ipv6=1
-            - net.ipv6.conf.all.disable_ipv6=1
-            - net.ipv6.conf.lo.disable_ipv6=1
-        # The container has no recovery logic. Use a healthcheck to catch disconnects.
-        # This can also be used to ensure the vpn is up before starting other containers
-        # using the vpn connection
-        healthcheck:
-            test: ping -c 1 www.google.com || exit 1
-            interval: 300s
-            timeout: 10s
-            retries: 3
-            start_period: 30s
-            start_interval: 3s
+  vpn:
+    image: thrnz/docker-wireguard-pia
+    # Alternatively you may use ghcr.io
+    #image: ghcr.io/thrnz/docker-wireguard-pia
+    container_name: docker-wireguard-pia
+    volumes:
+      #Auth token is stored here
+      - pia:/pia
+      # If enabled, the forwarded port is dumped to /pia-shared/port.dat for potential use in other containers
+      - pia-shared:/pia-shared
+    cap_add:
+      - NET_ADMIN
+  #SYS_MODULE might not be needed with a 5.6+ kernel?
+      #- SYS_MODULE
+      # If the kernel module isn't available, mounting the tun device may be necessary for userspace implementations
+  #devices:
+      #- /dev/net/tun:/dev/net/tun
+    environment:
+      # The following env vars are required:
+      - LOC=swiss
+      - USER=xxxxxxxxxxxxxxxx
+      - PASS=xxxxxxxxxxxxxxxx
+      #The rest are optional:
+      #- LOCAL_NETWORK=192.168.1.0/24
+      #- KEEPALIVE=25
+      #- VPNDNS=8.8.8.8,8.8.4.4
+      #- PORT_FORWARDING=1
+    sysctls:
+      # The wg-quick script tries to set this when setting up routing, however this requires running the container
+      # with the --privileged flag set. Setting it here instead if needed means the container can be run with lower
+      # privileges. This only needs setting if strict reverse path filtering (rp_filter=1) is used.
+      - net.ipv4.conf.all.src_valid_mark=1
+      # May as well disable ipv6. Should be blocked anyway.
+      - net.ipv6.conf.default.disable_ipv6=1
+      - net.ipv6.conf.all.disable_ipv6=1
+      - net.ipv6.conf.lo.disable_ipv6=1
+      # The container has no recovery logic. Use a healthcheck to catch disconnects.
+      # This can also be used to ensure the vpn is up before starting other containers
+      # using the vpn connection
+    healthcheck:
+      test: ping -c 1 www.google.com || exit 1
+      interval: 300s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+      start_interval: 3s
 
-    # Example of another service sharing the VPN
-    # If this service needs LAN access then LOCAL_NETWORK must be set appropriatley on the vpn container
-    # Forwared ports should also be set on the vpn container if needed rather than this one in
-    # order to access from the LAN
-    # It may be preferable to use a reverse proxy connected via the docker bridge network instead
-    # to keep the vpn isolated from the LAN
-    other-service:
-        image: some-other-image
-        # Other services can share the VPN using 'network_mode: "service:[service name]"'
-        # See https://docs.docker.com/engine/network/#container-networks and
-        # https://docs.docker.com/reference/compose-file/services/#network_mode
-        network_mode: "service:vpn"
-        # The following can be used to ensure the vpn is up and functional before the dependant service is started
-        depends_on:
-            vpn:
-                condition: service_healthy
+      # Example of another service sharing the VPN
+      # If this service needs LAN access then LOCAL_NETWORK must be set appropriatley on the vpn container
+      # Forwared ports should also be set on the vpn container if needed rather than this one in
+      # order to access from the LAN
+      # It may be preferable to use a reverse proxy connected via the docker bridge network instead
+      # to keep the vpn isolated from the LAN
+  #other-service:
+    #image: some-other-image
+    # Other services can share the VPN using 'network_mode: "service:[service name]"'
+    # See https://docs.docker.com/engine/network/#container-networks and
+    # https://docs.docker.com/reference/compose-file/services/#network_mode
+    #network_mode: "service:vpn"
+    # The following can be used to ensure the vpn is up and functional before the dependant service is started
+    #depends_on:
+      #vpn:
+        #condition: service_healthy
 
 
-    # Other containers can access the forwarded port number via /pia-shared/port.dat
-    # Here's an example of a bare-bones 'helper' container that passes the forwarded port to Deluge
-    # See https://gist.github.com/thrnz/dcbaa0af66c70af8e302a1c7eb75484a
-    deluge-port-helper:
-        build: /path/to/deluge-port-helper
-        volumes:
-            - pia-shared:/pia-shared:ro
-            - /path/to/deluge/conf:/deluge/conf
-        network_mode: "service:vpn"
-        depends_on:
-            - vpn
-            - other-service
+  # Other containers can access the forwarded port number via /pia-shared/port.dat
+  # Here's an example of a bare-bones 'helper' container that passes the forwarded port to Deluge
+  # See https://gist.github.com/thrnz/dcbaa0af66c70af8e302a1c7eb75484a
+  #deluge-port-helper:
+    #build: /path/to/deluge-port-helper
+    #volumes:
+      #- pia-shared:/pia-shared:ro
+      #- /path/to/deluge/conf:/deluge/conf
+    #network_mode: "service:vpn"
+    #depends_on:
+      #- vpn
+      #- other-service
 
 volumes:
-    pia:
-    pia-shared:
+  pia:
+  pia-shared:


### PR DESCRIPTION
Clean up the left margin spacing, add a container name, and add a comment reference for the alternative ghcr.io image to docker-compose.yml