### PR TITLE
Add back newline to token file

### DIFF
--- a/extra/pf.sh
+++ b/extra/pf.sh
@@ -148,7 +148,7 @@ get_sig () {
     # shellcheck disable=SC2086
     pf_getsig=$(curl --get --silent --show-error $iface_curl --connect-timeout "$curl_connection_timeout" \
       --retry "$curl_retry" --retry-delay "$curl_retry_delay" --max-time "$curl_max_time" \
-      --data-urlencode "token@$tokenfile" \
+      --data-urlencode "token=$(cat "$tokenfile")" \
       $verify \
       "https://$pf_host:19999/getSignature")
   fi


### PR DESCRIPTION
After updating my docker containers 2 weeks ago, one of my 3 containers using this image suddenly failed the port forwarding.
The error looked like this:
```
qbittorrent-private-static-vpn  | [pf] Tue Jul 29 08:45:02 UTC 2025: Verifying API requests. CN: frankfurt412
qbittorrent-private-static-vpn  | [pf] Tue Jul 29 08:45:02 UTC 2025: Getting PF token
qbittorrent-private-static-vpn  | [pf] Tue Jul 29 08:45:07 UTC 2025: getSignature error
qbittorrent-private-static-vpn  | [pf] {
qbittorrent-private-static-vpn  | [pf]     "status": "ERROR",
qbittorrent-private-static-vpn  | [pf]     "message": "Login failed!"
qbittorrent-private-static-vpn  | [pf] }
qbittorrent-private-static-vpn  | [pf] Tue Jul 29 08:45:07 UTC 2025: Fatal error
qbittorrent-private-static-vpn  | Tue Jul 29 08:45:07 UTC 2025: Port forwarding script closed
```

I didn't get around to it until today, but today I checked what caused this.
Since it says getSignature error, I looked in the pf.sh file for the function this happens in, and then checked recent commits and found the change that removes the newline from the authentication.
Since this is a change to the authentication token, I figured this might be the cause and upon undoing the change in a local container - the port forwarding resumed working and the error disappeared.

I tried this multiple times to make sure it wasn't just placebo, and this is in fact very reproducible.

What confuses me is that this only happens in one out of my 3 containers using this image..
But there is a distinct difference with this container compared to the other 2: The container encountering this issue was the only one using a dedicated IP token.

I am, not sure why exactly this happens only when using a dedicated IP. It makes sense for the removal of the newline itself to cause issues (see the explanation below) - but it doesn't make sense that it's inconsistent.
My best guess is that there is some difference in how PIA servers that use a dedicated IP vs those that don't parse the authentication token?
Or if maybe it's just the specific server that I am using? I am not sure.

But either way, since this change can cause issues it makes sense to undo it.
I am not sure if it makes sense to also undo the newline removals in other files that were done in https://github.com/thrnz/docker-wireguard-pia/commit/e5e9b92aa8cb42330864363fdd3c61335ffbaf19, but I think it would make sense.
It is usually quite standard for text files to have a newline at the end of the last line, and some tools or such might even expect it. (See https://sourabhkr.medium.com/why-should-text-files-end-with-a-newline-c2e08d4896b8 )
TL;DR: A newline denotes the "end" of a line of text, and a line of text without a newline is technically considered "incomplete" - similar to when a line of code in languages that require the use of semicolon is missing a ; - or a sentence that is missing a "." at the end.
There is a reason why commands like `cat` and `echo` default to appending a newline.
So removing this new line goes against established standards, and there is no real advantage to removing it, it only potentially introduces issues, as seen now. Hence I think it makes sense to undo that commit that removes the newlines entirely.

Either way it'd be great if this could be merged to fix this issue! Thank you!