### PR TITLE
Add workaround for an openresolv change for Alpine 3.23 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.23
 
 RUN apk add --no-cache \
     bash \

--- a/run
+++ b/run
@@ -410,6 +410,10 @@ gen_configs
 
 [ "$KEEPALIVE" -gt 0 ] && echo "PersistentKeepalive = $KEEPALIVE" >> "$wg_conf"
 
+# Let openresolv overwrite Docker's generated resolv.conf
+# https://github.com/NetworkConfiguration/openresolv/commit/0fdbfd03b554b82a8d5847d5fbecfa2814cf2499
+[ "${VPNDNS}" != "0" ] && resolvconf -u
+
 echo "Bringing up WireGuard interface wg0"
 wg-quick up wg0 || fatal_error
 


### PR DESCRIPTION
```
vpn-1  | resolvconf: signature mismatch: /etc/resolv.conf
vpn-1  | resolvconf: run `resolvconf -u` to update
```

openresolv 3.17.0, included in Alpine 3.23, no longer allows overwriting Docker's generated `/etc/resolv.conf` by default. 

Generate an empty `/etc/resolv.conf` before running `wg-quick up` so openresolv knows that it's allowed to overwrite it.