### PR TITLE
Fix a wg-quick issue on some setups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     libcap-utils \
     jq \
     openssl \
+    patch \
     sed \
     tini \
     wireguard-go \
@@ -17,8 +18,9 @@ RUN apk add --no-cache \
 
 # Modify wg-quick so it doesn't die without --privileged
 # Set net.ipv4.conf.all.src_valid_mark=1 on container creation using --sysctl if required instead
-# To avoid confusion, also suppress the error message that displays even when pre-set to 1 on container creation
-RUN sed -i 's/cmd sysctl.*/set +e \&\& sysctl -q net.ipv4.conf.all.src_valid_mark=1 \&> \/dev\/null \&\& set -e/' /usr/bin/wg-quick
+ADD ./patches/wg-quick.diff /tmp/wg-quick.diff
+RUN patch /usr/bin/wg-quick < /tmp/wg-quick.diff && \
+	rm /tmp/wg-quick.diff
 
 ADD https://raw.githubusercontent.com/pia-foss/desktop/master/daemon/res/ca/rsa_4096.crt /rsa_4096.crt
 

--- a/patches/wg-quick.diff
+++ b/patches/wg-quick.diff
@@ -1,0 +1,11 @@
+--- ./wg-quick	2026-06-19 15:55:45.603812600 +1200
++++ ./wg-quick	2026-06-18 18:40:30.280529700 +1200
+@@ -238,7 +238,7 @@
+ 	printf -v restore '%sCOMMIT\n*mangle\n-I POSTROUTING -m mark --mark %d -p udp -j CONNMARK --save-mark %s\n-I PREROUTING -p udp -j CONNMARK --restore-mark %s\nCOMMIT\n' "$restore" $table "$marker" "$marker"
+ 	printf -v nftcmd '%sadd rule %s %s postmangle meta l4proto udp mark %d ct mark set mark \n' "$nftcmd" "$pf" "$nftable" $table
+ 	printf -v nftcmd '%sadd rule %s %s premangle meta l4proto udp meta mark set ct mark \n' "$nftcmd" "$pf" "$nftable"
+-	[[ $proto == -4 ]] && [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) -ne 1 ]] && cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1
++	[[ $proto == -4 ]] && set +e && [[ $(sysctl -n net.ipv4.conf.all.src_valid_mark) -ne 1 ]] && sysctl -q net.ipv4.conf.all.src_valid_mark=1; set -e
+ 	if type -p nft >/dev/null; then
+ 		cmd nft -f <(echo -n "$nftcmd")
+ 	else


### PR DESCRIPTION
A recently added comparison seems to trigger Bash's 'set -e' behavior.

Fixes #179

See: https://git.zx2c4.com/wireguard-tools/commit/src/wg-quick/linux.bash?id=ac74ed6d7dd4d77f56c7f05c053a5e645e0e33a0